### PR TITLE
Replace regex \n with [\s\S]+ in getPackageVersions()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ ADBDevice.prototype = {
     var result = [];
   
     if (output.trim().length) {
-      const re = /versionCode=(\d+).+\n.+versionName=(.+)/gmi;
+      const re = /versionCode=(\d+).+[\s\S]+.+versionName=(.+)/gmi;
       while (res = re.exec(output)) {
         const versionCode = res[1];
         const versionName = res[2];


### PR DESCRIPTION
In my Windows 10, new line code seems `\r\n` in the strings returned from `adb` command. Then `\n` in  `/versionCode=(\d+).+\n.+versionName=(.+)/gmi;` didn't match with new line. Replacing `\n` with `[\s\S]+` fixes this issue.